### PR TITLE
Change default keybinds for "Play Random Emote" and "Join Emote" actions to avoid conflicts with other mods

### DIFF
--- a/CustomEmotesAPI/Utils/EmotesInputSettings.cs
+++ b/CustomEmotesAPI/Utils/EmotesInputSettings.cs
@@ -19,10 +19,10 @@ namespace LethalEmotesAPI
         [InputAction("<Mouse>/rightButton", Name = "CustomEmotesAPI: Cycle Wheel Right")]
         public InputAction Right { get; set; }
 
-        [InputAction("<Keyboard>/f", Name = "CustomEmotesAPI: Play Random Emote")]
+        [InputAction("<Keyboard>/comma", Name = "CustomEmotesAPI: Play Random Emote")]
         public InputAction RandomEmote {  get; set; }
 
-        [InputAction("<Keyboard>/v", Name = "CustomEmotesAPI: Join Emote")]
+        [InputAction("<Keyboard>/period", Name = "CustomEmotesAPI: Join Emote")]
         public InputAction JoinEmote { get; set; }
 
         [InputAction("", Name = "Stop emoting")]


### PR DESCRIPTION
Current keybinds for `CustomEmotesAPI: Play Random Emote` and `CustomEmotesAPI: Join Emote` conflict with other emotes like `ReservedFlashlightSlot` and `More Emotes`. After an investigation, I found out the `comma` and `period` key are pretty much free to use in this case.